### PR TITLE
'better_errors' を追加したが、エラー画面がデフォルトのままになる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ group :development, :test do
   gem 'rails_best_practices'
   gem 'rspec-rails'
   gem 'factory_bot_rails'
+  gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,13 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.2.4.0)
       execjs
+    better_errors (2.9.1)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
     bindex (0.8.1)
+    binding_of_caller (1.0.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.7.3)
       msgpack (~> 1.0)
     bootstrap-sass (3.4.1)
@@ -70,8 +76,10 @@ GEM
     childprocess (4.0.0)
     code_analyzer (0.5.2)
       sexp_processor
+    coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
+    debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     erubi (1.10.0)
     erubis (2.7.0)
@@ -262,6 +270,8 @@ PLATFORMS
   x86_64-darwin-19
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   bootsnap (>= 1.4.2)
   bootstrap-sass (= 3.4.1)
   byebug

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,3 +60,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end
+
+BetterErrors::Middleware.allow_ip! "0.0.0.0/0"


### PR DESCRIPTION
## 質問内容

* gem 'better_errors' 'binding_of_caller' を追加したが、デフォルトのエラー画面のままになってしまう。
[![Image from Gyazo](https://i.gyazo.com/f4d3b96795ab01dd471dd9531fcba736.png)](https://gyazo.com/f4d3b96795ab01dd471dd9531fcba736)

## 実現したいこと

* 'better_errors'  対応のエラー画面にしたい
[![Image from Gyazo](https://i.gyazo.com/07333089cd5d4a26b42d6754f1ec505c.png)](https://gyazo.com/07333089cd5d4a26b42d6754f1ec505c)

## 実施内容
* config/environments/development.rb に下記を追記し、サーバー、PC再起動したが、エラー画面変わらず。
`BetterErrors::Middleware.allow_ip! "0.0.0.0/0"`

- 上記テキストを config/environments/development.rb の`end`内に移動してもエラー画面変わらず。

* [エラー対応資料](https://github.com/BetterErrors/better_errors/issues/270)

## 備考

- 他のアプリでは'better_errors' を導入しているものはエラー画面が対応している
- MySQLのみDockerでbuildしています