### PR TITLE
bundlerのバージョンを2.2.6から2.1.4に変更

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.9.0)
+    loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -116,17 +116,19 @@ GEM
     marcel (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.4)
     msgpack (1.4.2)
     mysql2 (0.5.3)
     nio4r (2.5.7)
-    nokogiri (1.11.2-x86_64-darwin)
+    nokogiri (1.11.3)
+      mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     overcommit (0.57.0)
       childprocess (>= 0.6.3, < 5)
       iniparse (~> 1.4)
     parallel (1.20.1)
-    parser (3.0.0.0)
+    parser (3.0.1.0)
       ast (~> 2.4.1)
     popper_js (1.16.0)
     puma (4.3.7)
@@ -178,7 +180,7 @@ GEM
       ffi (~> 1.0)
     regexp_parser (2.1.1)
     require_all (3.0.0)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -272,7 +274,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  x86_64-darwin-19
+  ruby
 
 DEPENDENCIES
   better_errors
@@ -308,4 +310,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.6
+   2.1.4


### PR DESCRIPTION
## 変更の概要

* bundlerのバージョンを2.2.6から2.1.4に変更

## なぜこの変更をするのか

* herokuがbundler - 2.2.6 サポートしていないため、デプロイ時にエラーになるのでバージョン変更


## 変更内容

* bundlerのバージョンを2.2.6から2.1.4に変更

## 影響範囲

* 依存関係があるgemに不具合が発生する可能性があるかも

##  確認方法

1. Gemfile.lockを削除
2. gem uninstall bunder -v 2.2.6
3. gem install bundler -v 2.1.4
4. bundler -v  #バージョン確認
