### PR TITLE
DBのバージョン変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group :development, :test do
   gem 'better_errors'
   gem 'binding_of_caller'
   # gem 'mysql2', '>= 0.4.4'
-  gem 'sqlite3', '1.4.1'
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.1)
+    sqlite3 (1.3.13)
     temple (0.8.2)
     thor (1.1.0)
     thread_safe (0.3.6)
@@ -303,7 +303,7 @@ DEPENDENCIES
   slim-rails
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3 (= 1.4.1)
+  sqlite3 (~> 1.3.6)
   tzinfo-data
   web-console (>= 3.3.0)
   webpacker (~> 4.0)


### PR DESCRIPTION
## 変更の概要

* sqlite3のバージョンを'1.4.1'から 1.3.6'に変更

## なぜこの変更をするのか

* herokuがサポートしていないバージョンのため、デプロイできない

## 変更内容

* sqlite3のバージョンを'1.4.1'から 1.3.6'に変更
