### PR TITLE
herokuデプロイ時のSprockets::ArgumentError: link_directory argument must be a directory 対応

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,1 +1,0 @@
-//= link_directory ../stylesheets .css


### PR DESCRIPTION
## 変更の概要

* herokuデプロイ時 link_directory argument must be a directory 対応

## なぜこの変更をするのか

* herokuデプロイ時 link_directory argument must be a directoryとなるため

## 変更内容

- manifest.js の//= link_directory ../stylesheets .css 読み込み削除 
