### PR TITLE
Googleアナリティクス トラッキング ID修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -110,6 +110,6 @@ Rails.application.configure do
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
-  GA.tracker = "269430318"
+  GA.tracker = "UA-194915211-1"
 
 end


### PR DESCRIPTION
## 変更の概要

* Googleアナリティクス トラッキング ID修正
* close #40 

## なぜこの変更をするのか

* トラッキングIDをUAから始まるものにしておらず、反映されていなかったため

## 変更内容

* トラッキングIDをUAから始まるものに変更

##  確認方法

* Googleアナリティクスに反映されているか確認
