### PR TITLE
Twitterシェアボタン設置

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem 'slim-rails'
 gem 'html2slim'
 gem 'bootstrap-sass'
 gem 'bootstrap'
+gem 'font-awesome-sass'
 
 # Authentication
 gem 'sorcery'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
       ruby2_keywords
     faraday-net_http (1.0.1)
     ffi (1.15.0)
+    font-awesome-sass (5.15.1)
+      sassc (>= 1.11)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     google-analytics-rails (1.1.1)
@@ -307,6 +309,7 @@ DEPENDENCIES
   bootstrap-sass
   byebug
   factory_bot_rails
+  font-awesome-sass
   google-analytics-rails
   html2slim
   jbuilder (~> 2.7)

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -12,6 +12,7 @@ window.$ = window.jQuery = jQuery;
 
 import 'packs/stylesheets/application';
 import 'bootstrap';
+import '@fortawesome/fontawesome-free/js/all';
 // import '../stylesheets/application';
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/javascript/packs/challenge.js.erb
+++ b/app/javascript/packs/challenge.js.erb
@@ -12,6 +12,7 @@ let starttime, cleartime;
 let correctAnswers = 0;
 let remainingProblems = 10;
 let errorCount = 0;
+const result_twitter = document.querySelector('#js-result-twitter');
 
 function andMeta(event, event_key, answer_key, modifier_key, question) {
     if (event_key === answer_key && event.metaKey) {
@@ -198,6 +199,7 @@ function replacement(answer_key, modifier_key, question) {
         document.querySelector('#correctAnswers').innerHTML = `正解数は${correctAnswers}問です`;
         document.querySelector('#errorCount').innerHTML = `ミス入力は${errorCount}回です`;
         result.innerHTML = `クリアタイムは${cleartime}秒です`;
+        result_twitter.href = result_twitter.href.replace('cleartime', String(cleartime));
     } else {
         arrs.shift();
         document.querySelector('#img').setAttribute('src', `${arrs[0].question}.gif`);
@@ -212,11 +214,15 @@ function timeUp() {
     remainingProblems--;
     if (remainingProblems == 0) {
         cleartime = Math.round((Date.now() - starttime) / 1000);
+        result.style.display = "block";
         document.querySelector('#game').style.display = "none";
+        document.querySelector('#hint').style.display = "none";
         document.querySelector('#timer').style.display = "none";
+        document.querySelector('#finish').style.display = "block";
         document.querySelector('#correctAnswers').innerHTML = `正解数は${correctAnswers}問です`;
         document.querySelector('#errorCount').innerHTML = `ミス入力は${errorCount}回です`;
         result.innerHTML = `クリアタイムは${cleartime}秒です`;
+        result_twitter.href = result_twitter.href.replace('cleartime', String(cleartime));
     } else {
         document.querySelector('#remainingProblems').innerHTML = `残り問題数:${remainingProblems}`;
         arrs.shift();
@@ -282,7 +288,6 @@ window.addEventListener('keydown',event => {
         $('#timer').timer(10);
         document.querySelector('#img').setAttribute('src', `${arrs[0].question}.gif`);
         document.querySelector('#game').style.display = "block";
-//        document.querySelector('#correctAnswers').style.display = "block";
         document.querySelector('#description').style.display = "none";
         problemStatement.innerHTML = arrs[0].question;
         document.querySelector('#answer').innerHTML = `${arrs[0].display_key}`;

--- a/app/javascript/packs/stylesheets/application.scss
+++ b/app/javascript/packs/stylesheets/application.scss
@@ -1,4 +1,5 @@
 @import '~bootstrap/scss/bootstrap';
+@import '~@fortawesome/fontawesome-free/scss/fontawesome';
 
 // gifサイズ調整
 .image-trim img {

--- a/app/views/challenges/index.html.slim
+++ b/app/views/challenges/index.html.slim
@@ -24,6 +24,9 @@
       h3#correctAnswers.card-text.my-5
       h3#result.card-text.my-5
       h3#errorCount.card-text.my-5
+      p = link_to "https://twitter.com/intent/tweet?text=タイム%20:%20cleartime秒でした！%0a%0a%23Test%0a\&url=#{request.url}", target: :_blank, rel: 'noopener noreferrer', class: 'button is-info text-decoration-none my-3', id: 'js-result-twitter' do
+        i.fab.fa-twitter.mr-1
+        span 結果をTwitterでシェア
       = link_to "最初から遊ぶ", challenges_path, class: "btn btn-lg btn-primary my-3"
   div#game[style="display:none;"]
     h3#status-area　

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "shortcut_key_game",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.15.3",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -754,6 +754,10 @@
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
 
+"@fortawesome/fontawesome-free@^5.15.3":
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.3.tgz#c36ffa64a2a239bf948541a97b6ae8d729e09a9a"
+
 "@npmcli/move-file@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.1.2.tgz#1a82c3e372f7cae9253eb66d72543d6b8685c674"


### PR DESCRIPTION
## 変更の概要

* Twitterシェアボタン設置
* ゲームのクリアタイムを表示
* close #39 

## なぜこの変更をするのか

* Twitterシェアできるようにするため

## 変更内容

* Twitterシェアボタン[![Image from Gyazo](https://i.gyazo.com/278b21a40ee277cab6f475f3ca2b689e.png)](https://gyazo.com/278b21a40ee277cab6f475f3ca2b689e)
* Twitter画面[![Image from Gyazo](https://i.gyazo.com/1a30bad87fc055395e4374f375d3b872.png)](https://gyazo.com/1a30bad87fc055395e4374f375d3b872)

##  確認方法

1. /time_attacksにアクセスして、ゲームを開始してください
2. ゲーム終了時にTwitterシェアボタンがあることを確認してください
3. Twitterシェアボタンを押すと、Twitterに遷移し、上記のTwitter画面のつぶやきになっていることを確認してください
