### PR TITLE
SendGridの設定追加

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'yasu6491@icloud.com'
   layout 'mailer'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,7 +61,24 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "shortcut_key_game_production"
 
   config.action_mailer.perform_caching = false
-
+  # deliverメソッドを実行したときに、true なら、メール配信を行なう。
+  config.action_mailer.perform_deliveries = true
+  # メール配信に失敗した場合にエラーを発生するかどうかを指定
+  # このオプションは、外部のメールサーバーが即時配信を行っている場合にのみ機能
+  config.action_mailer.raise_delivery_errors = true
+  # SMTP プロトコルによるメール配信を行う。
+  config.action_mailer.delivery_method = :smtp
+  # smtpの配信メソッドの詳細設定
+  # SENDGRID用
+  config.action_mailer.smtp_settings = {
+    address: 'smtp.sendgrid.net',
+    port: 587,
+    domain: 'heroku.com',
+    user_name: ENV['SENDGRID_USERNAME'],
+    password: ENV['SENDGRID_APIKEY'],
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -70,6 +70,8 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
   # smtpの配信メソッドの詳細設定
   # SENDGRID用
+  config.action_mailer.default_url_options = { host: 'vs-magic.com' }
+
   config.action_mailer.smtp_settings = {
     address: 'smtp.sendgrid.net',
     port: 587,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,7 +74,7 @@ Rails.application.configure do
     address: 'smtp.sendgrid.net',
     port: 587,
     domain: 'heroku.com',
-    user_name: ENV['SENDGRID_USERNAME'],
+    user_name: 'apikey',
     password: ENV['SENDGRID_APIKEY'],
     authentication: :plain,
     enable_starttls_auto: true


### PR DESCRIPTION
## 変更の概要

* SendGridの設定
* 本番環境でメールを送信すると`Missing host to link to! Please provide the :host parameter, set default_url_options[:host], or set :only_path to true`になるので設定修正

